### PR TITLE
Create addon_data and temp directories

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/core.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/core.py
@@ -120,7 +120,7 @@ def download_subs(link, referrer, filename):
     # Re-create a download location in a temporary folder
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
-    os.mkdir(temp_dir)
+    xbmcvfs.mkdirs(temp_dir)
     # Combine a path where to download the subs
     filename = os.path.splitext(filename)[0] + '.srt'
     subspath = os.path.join(temp_dir, filename)


### PR DESCRIPTION
When the addon runs for the first time and I download a subtitle, it gives the following error:
```
Error Contents: [Errno 2] No such file or directory: '/storage/.kodi/userdata/addon_data/service.subtitles.rvm.addic7ed/temp'
```
Add a fix using xbmcvfs