### PR TITLE
Content decoding relies on charset

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
@@ -112,10 +112,10 @@ class Response:
         """
         if self._text is None:
             charset = self.headers.get_content_charset()
-            if charset and len(charset) > 0:
+            if charset:
                 self._text = self.content.decode(charset.lower())
             else:
-                self._text = self.content
+                self._text = self.content.decode(self.encoding, errors='replace')
         return self._text
 
     def json(self) -> Optional[Union[Dict[str, Any], List[Any]]]:

--- a/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
@@ -111,7 +111,11 @@ class Response:
         :return: Response payload as decoded text
         """
         if self._text is None:
-            self._text = self.content.decode(self.encoding)
+            charset = self.headers.get_content_charset()
+            if charset and len(charset) > 0:
+                self._text = self.content.decode(charset.lower())
+            else:
+                self._text = self.content
         return self._text
 
     def json(self) -> Optional[Union[Dict[str, Any], List[Any]]]:


### PR DESCRIPTION
UTF-8 decoding fails when non UTF-8 content is returned (ex: French and Portuguese of https://www.addic7ed.com/serie/Evil/4/4/How_to_Build_a_Coffin)

With this PR, content is decoded if a charset is present (English and Portuguese in the example) or directly returned if no t (French in the example)